### PR TITLE
fix: data in numbers api response

### DIFF
--- a/src/app/Http/Controllers/Api/DroneController.php
+++ b/src/app/Http/Controllers/Api/DroneController.php
@@ -59,10 +59,8 @@ class DroneController extends Controller
         $totalEmission = Drone::whereHas('emissions')->count();
         return response()->json([
             'message' => 'Success',
-            'data' => [
-                'Drone' => $total,
-                'Drones with emission' => $totalEmission
-            ]
+            'all' => $total,
+            'withEmission' => $totalEmission
         ], 200);
     }
 
@@ -76,9 +74,7 @@ class DroneController extends Controller
                 })->count();
                 return response()->json([
                     'message' => 'Success',
-                    'data' => [
-                        'Drones with emission' => $droneWithEmission
-                    ]
+                    'data' => $droneWithEmission
                 ], 200);
             } else {
                 return response()->json([

--- a/src/app/Http/Controllers/Api/EmissionController.php
+++ b/src/app/Http/Controllers/Api/EmissionController.php
@@ -334,7 +334,6 @@ class EmissionController extends Controller
                 ], 404);
             }
 
-            // Get the latest emission for the port
             $lastEmission = Emission::where('port_id', $port->id)->orderBy('date', 'desc')->first();
 
             if(!$lastEmission){
@@ -344,13 +343,10 @@ class EmissionController extends Controller
                 ], 404);
             }
 
-            // Get the latest emission data associated with the last emission based on date
             $lastEmissionData = $lastEmission->emissionData()->orderBy('date', 'desc')->first();
 
-            // Extract date and time from the latest emission data
             $lastEmissionDateTime = date('d F Y, H:i', strtotime($lastEmissionData->date . ' ' . $lastEmissionData->time));
 
-            // Calculate total emission data
             $totalEmissionData = $lastEmission->emissionData->count();
             $totalNO2 = $lastEmission->emissionData->sum('NO2');
             $totalNO = $lastEmission->emissionData->sum('NO');

--- a/src/app/Http/Controllers/Api/VesselController.php
+++ b/src/app/Http/Controllers/Api/VesselController.php
@@ -58,10 +58,8 @@ class VesselController extends Controller
             $vesselWithEmission = Vessel::whereHas('emissions')->count();
             return response()->json([
                 'message' => 'Success',
-                'data' => [
-                    'Vessel' => $total,
-                    'Vessel with emission' => $vesselWithEmission
-                ]
+                'all' => $total,
+                'withEmission' => $vesselWithEmission
             ], 200);
         } catch (\Exception $e) {
             return response()->json([
@@ -88,9 +86,7 @@ class VesselController extends Controller
 
             return response()->json([
                 'message' => 'Success',
-                'data' => [
-                    'Vessel with emission' => $vesselWithEmission
-                ]
+                'data' => $vesselWithEmission
             ], 200);
         } catch (\Exception $e) {
             return response()->json([

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -54,12 +54,10 @@ Route::middleware('auth:sanctum')->group(function () {
         // Vessel
         Route::get('vessels', [VesselController::class, 'getAll']);
         Route::get('vessels/{id}', [VesselController::class, 'getVesselbyId']);
-        Route::get('vessels/s/total', [VesselController::class, 'getTotalVesselWithEmissions']);
 
         // Drone
         Route::get('drones', [DroneController::class, 'getAll']);
         Route::get('drones/{id}', [DroneController::class, 'getDronebyId']);
-        Route::get('drones/s/total', [DroneController::class, 'getTotalDroneWithEmissions']);
         Route::post('drones', [DroneController::class, 'createDrone']);
         Route::post('drones/update', [DroneController::class, 'updateDrone']);
         Route::delete('drones/{id}', [DroneController::class, 'deleteDrone']);
@@ -95,14 +93,16 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::post('emission-pilot', [EmissionUserController::class, 'setSniffingPilot']);
 
         // Data in Numbers
+        Route::get('drones/s/total', [DroneController::class, 'getTotalDroneWithEmissions']);
+        Route::get('vessels/s/total', [VesselController::class, 'getTotalVesselWithEmissions']);
         Route::get('ports/b/total', [PortController::class, 'getTotalPort']);
         Route::get('vessels/b/total', [VesselController::class, 'getTotalVessel']);
         Route::get('drones/b/total', [DroneController::class, 'getTotalDrone']);
         Route::get('pilots/b/total', [UserController::class, 'getTotalPilot']);
-        Route::get('vessels/onport/{portId}', [VesselController::class, 'getTotalVesselOnPort']);
-        Route::get('drones/onport/{portId}', [DroneController::class, 'getTotalDroneOnPort']);
-        Route::get('pilot/onport/{portId}', [UserController::class, 'getTotalPilotOnPort']);
-        Route::get('emissions/onport/{portId}', [EmissionController::class, 'getTotalEmissionOnPort']);
+        Route::get('vessels/p/{portId}', [VesselController::class, 'getTotalVesselOnPort']);
+        Route::get('drones/p/{portId}', [DroneController::class, 'getTotalDroneOnPort']);
+        Route::get('pilots/p/{portId}', [UserController::class, 'getTotalPilotOnPort']);
+        Route::get('emissions/p/{portId}', [EmissionController::class, 'getTotalEmissionOnPort']);
     });
 
     Route::middleware('role:BKI,PORT')->group(function () {
@@ -124,9 +124,5 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::post('emissions', [EmissionController::class, 'createEmission']);
         Route::post('update/emissions', [EmissionController::class, 'updateEmission']);
         Route::delete('emissions/{id}', [EmissionController::class, 'deleteEmission']);
-    });
-
-    Route::middleware('role:BKI,PILOT')->group(function () {
-        // Pilot
     });
 });


### PR DESCRIPTION
**Route naming**

- api/vessels/onport/{portId} -> api/vessels/p/{portId}
- api/drones/onport/{portId} -> api/drones/p/{portId}
- api/pilot/onport/{portId} -> api/pilots/p/{portId}
- api/emissions/onport/{portId} -> api/emissions/p/{portId}

**Response standarization**

- api/drones/s/total
from
`
'message' => {status},
'data' => [
       'Drone' => $total,
       'Drones with emission' => $totalEmission
]
`
to
`
'message' => {status},
'all' => $total,
'withEmission' => $totalEmission
`
- /api/drones/p/{portId}
from
`
'message' => {status},
'data' => [
       'Drones with emission' => $totalEmission
]
`
to
`
'message' => {status},
'data' => $droneWithEmission
`
- /api/vessels/s/total
from
`
'message' => {status},
'data' => [
       'Vessel' => $total
       'Vessel with emission' => $vesselWithEmission
]
`
to
`
'message' => {status},
'all' => $total,
'withEmission' => $totalEmission
`
- /api/vessels/p/{portId}
from
`
'message' => {status},
'data' => [
       'Vessel with emission' => $vesselWithEmission
]
`
to
`
'message' => {status},
'data' => $total,
`
